### PR TITLE
Import extensions: ignore packages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -115,7 +115,7 @@
 		"no-duplicate-imports": "error",
 		"import/extensions": [ 
 			"warn",
-			"always"
+			"ignorePackages"
 		],
 		"no-extend-native": "error",
 		"no-extra-label": "error",


### PR DESCRIPTION
`import { writable } from 'svelte/store';` gives `Missing file extension for "svelte/store"` at this moment. This PR suppresses this warning for package imports.

See also: Johbog/eslint-config-nodejs#9.