### PR TITLE
 Ignore unused vars that start with `_`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -101,7 +101,12 @@
 			"error",
 			"unix"
 		],
-		"no-unused-vars": "warn",
+		"no-unused-vars": [
+			"warn",
+			{
+				"varsIgnorePattern": "^_"
+			}
+		],
 		"no-alert": "error",
 		"no-caller": "error",
 		"no-confusing-arrow": [


### PR DESCRIPTION
This addition allows unused variables that start with an underscore. Consider the following examples:

```javascript
const [ _, spread1, spread2 ] = array;
const unusedArg = (_, arg2) => console.log(arg2);
for (const [ _, value ] of map.entries()) {...}
```

```svelte
{#each array as _, index}
```

See also: Johbog/eslint-config-nodejs#12.